### PR TITLE
Add feed item status enum migration

### DIFF
--- a/migrations/0001_feed_item_status_enum.sql
+++ b/migrations/0001_feed_item_status_enum.sql
@@ -1,0 +1,26 @@
+-- Add an enum for tracking feed item ingestion status.
+-- This migration is written for PostgreSQL and will safely
+-- create the type only if it does not already exist.
+-- It also ensures a placeholder table exists so the enum
+-- is referenced somewhere concrete.
+
+BEGIN;
+
+DO $$
+BEGIN
+    CREATE TYPE feed_item_status AS ENUM ('pending', 'ingested', 'failed');
+EXCEPTION
+    WHEN duplicate_object THEN
+        NULL;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS feed_items (
+    id SERIAL PRIMARY KEY,
+    title TEXT NOT NULL,
+    link TEXT NOT NULL,
+    published TEXT,
+    status feed_item_status NOT NULL DEFAULT 'pending'
+);
+
+COMMIT;

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,19 @@
+# Migrations
+
+This repository stores database migrations as simple SQL files that can be
+executed against a PostgreSQL database.
+
+## Applying migrations
+
+1. Connect to your PostgreSQL instance with sufficient privileges to create
+   enums and tables.
+2. Run each migration file in order:
+
+   ```bash
+   psql "$DATABASE_URL" -f migrations/0001_feed_item_status_enum.sql
+   ```
+
+The first migration introduces the `feed_item_status` enum with values
+`pending`, `ingested`, and `failed`, and ensures a `feed_items` table exists
+that uses the enum. The migration is idempotent: rerunning it will not fail if
+the enum or table already exists.


### PR DESCRIPTION
## Summary
- add a PostgreSQL migration that introduces a `feed_item_status` enum and ensures a `feed_items` table references it
- document how to apply migrations and note the idempotent behavior of the migration

## Testing
- python -m compileall ingestor

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c4a767c048320a223037500408209)