### PR TITLE
Add safety tracking fields and gift payload support

### DIFF
--- a/ded_moroz/db/models.py
+++ b/ded_moroz/db/models.py
@@ -22,6 +22,18 @@ class UserStatus(str, enum.Enum):
     STOPPED = "stopped"
 
 
+class SafetyStatus(str, enum.Enum):
+    SAFE = "safe"
+    NEEDS_REVIEW = "needs_review"
+    BLOCKED = "blocked"
+
+
+class GiftType(str, enum.Enum):
+    TEXT = "text"
+    URL = "url"
+    PAYLOAD = "payload"
+
+
 class NotificationType(str, enum.Enum):
     REMINDER = "reminder"
     MISSED = "missed"
@@ -48,6 +60,10 @@ class User(Base):
     opted_in_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    enrolled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    paused_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    stopped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     submissions: Mapped[list[Submission]] = relationship("Submission", back_populates="user")
 
@@ -59,6 +75,8 @@ class Gift(Base):
     day: Mapped[int] = mapped_column(Integer, unique=True, nullable=False)
     gift_text: Mapped[str | None] = mapped_column(String)
     gift_url: Mapped[str | None] = mapped_column(String)
+    gift_type: Mapped[GiftType] = mapped_column(Enum(GiftType, **_enum_values), default=GiftType.TEXT, nullable=False)
+    payload: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
 
@@ -75,6 +93,9 @@ class Submission(Base):
     scores: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     reasons: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     safety_flag: Mapped[bool] = mapped_column(Boolean, default=False)
+    safety_status: Mapped[SafetyStatus] = mapped_column(
+        Enum(SafetyStatus, **_enum_values), default=SafetyStatus.SAFE, nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     user: Mapped[User] = relationship("User", back_populates="submissions")
@@ -92,6 +113,9 @@ class PoemAttempt(Base):
     scores: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     reasons: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
     safety_flag: Mapped[bool] = mapped_column(Boolean, default=False)
+    safety_status: Mapped[SafetyStatus] = mapped_column(
+        Enum(SafetyStatus, **_enum_values), default=SafetyStatus.SAFE, nullable=False
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     user: Mapped[User] = relationship("User")
@@ -116,6 +140,7 @@ class ErrorLog(Base):
     __tablename__ = "error_logs"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    service_name: Mapped[str | None] = mapped_column(String(255))
     level: Mapped[SeverityLevel] = mapped_column(Enum(SeverityLevel, **_enum_values), nullable=False)
     message: Mapped[str] = mapped_column(String, nullable=False)
     context: Mapped[dict[str, Any] | None] = mapped_column(JSON().with_variant(JSONB, "postgresql"))
@@ -129,6 +154,7 @@ class ServiceHeartbeat(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     service_name: Mapped[str] = mapped_column(String(255), nullable=False)
     last_beat_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    beat_interval_seconds: Mapped[int] = mapped_column(Integer, default=600, nullable=False)
 
 
 class AdminErrorQueue(Base):

--- a/ded_moroz/handlers/commands.py
+++ b/ded_moroz/handlers/commands.py
@@ -4,8 +4,10 @@ from aiogram import F, Router
 from aiogram.filters import Command, CommandObject
 from aiogram.types import Message
 
+import json
+
 from ded_moroz.config import settings
-from ded_moroz.db.models import SeverityLevel, UserStatus
+from ded_moroz.db.models import GiftType, SeverityLevel, UserStatus
 from ded_moroz.handlers.helpers import format_status, is_admin
 from ded_moroz.llm.client import LlmResponse, OpenRouterClient
 from ded_moroz.services import submissions as submissions_service
@@ -16,6 +18,20 @@ from ded_moroz.utils.time import current_campaign_day, is_before_start, is_campa
 
 router = Router()
 llm_client = OpenRouterClient()
+
+
+def _format_gift_line(gift: object) -> str:
+    if not gift:
+        return "Подарок пока не настроен."
+    if getattr(gift, "gift_type", None) == GiftType.PAYLOAD and getattr(gift, "payload", None) is not None:
+        return json.dumps(gift.payload, ensure_ascii=False)
+    if getattr(gift, "gift_type", None) == GiftType.URL and getattr(gift, "gift_url", None):
+        return gift.gift_url
+    if getattr(gift, "gift_text", None):
+        return gift.gift_text
+    if getattr(gift, "gift_url", None):
+        return gift.gift_url
+    return "Подарок пока не настроен."
 
 
 @router.message(Command("start"))
@@ -123,9 +139,34 @@ async def cmd_set_gift(message: Message, command: CommandObject) -> None:
         await message.answer("Нужно указать день и текст")
         return
     day = int(parts[0])
-    gift_text = parts[1]
-    gift_url = parts[2] if len(parts) == 3 else None
-    gift = await set_gift(day, gift_text, gift_url)
+    raw_type_or_text = parts[1]
+    gift_type = GiftType.TEXT
+    payload_data: dict | None = None
+    gift_text: str | None = None
+    gift_url: str | None = None
+
+    if raw_type_or_text in {t.value for t in GiftType}:
+        gift_type = GiftType(raw_type_or_text)
+        if len(parts) < 3:
+            await message.answer("Нужно указать содержимое подарка для выбранного типа.")
+            return
+        content = parts[2]
+    else:
+        content = raw_type_or_text
+        gift_url = parts[2] if len(parts) == 3 else None
+
+    if gift_type == GiftType.TEXT:
+        gift_text = content
+    elif gift_type == GiftType.URL:
+        gift_url = content
+    elif gift_type == GiftType.PAYLOAD:
+        try:
+            payload_data = json.loads(content)
+        except json.JSONDecodeError:
+            await message.answer("Payload должен быть валидным JSON.")
+            return
+
+    gift = await set_gift(day, gift_type, gift_text, gift_url, payload_data)
     await message.answer(f"Подарок на день {gift.day} обновлён.")
 
 
@@ -141,7 +182,10 @@ async def cmd_get_gift(message: Message, command: CommandObject) -> None:
     if not gift:
         await message.answer("Подарок не найден")
         return
-    await message.answer(f"День {gift.day}: {gift.gift_text or ''} {gift.gift_url or ''}")
+    payload_line = f" payload={gift.payload}" if gift.payload else ""
+    await message.answer(
+        f"День {gift.day}: тип={gift.gift_type.value} текст={gift.gift_text or ''} url={gift.gift_url or ''}{payload_line}"
+    )
 
 
 @router.message(Command("admin_errors"))
@@ -197,7 +241,7 @@ async def cmd_admin_health(message: Message) -> None:
     if not heartbeats:
         await message.answer("Пульс не найден")
         return
-    lines = [f"{hb.service_name}: {hb.last_beat_at}" for hb in heartbeats]
+    lines = [f"{hb.service_name}: {hb.last_beat_at} (freq: {hb.beat_interval_seconds}s)" for hb in heartbeats]
     await message.answer("\n".join(lines))
 
 
@@ -223,7 +267,7 @@ async def process_poem(message: Message) -> None:
     day = current_campaign_day()
     if await submissions_service.has_submission(user.id, day):
         gift = await get_gift_for_day(day)
-        gift_line = gift.gift_text or gift.gift_url or "Подарок уже был выдан."
+        gift_line = _format_gift_line(gift)
         await message.answer(f"На сегодня всё! {gift_line}")
         return
 
@@ -244,6 +288,7 @@ async def process_poem(message: Message) -> None:
             llm_result.scores,
             llm_result.reasons,
             llm_result.safety_flag,
+            llm_result.safety_status,
         )
         if llm_result.decision == "ACCEPT":
             try:
@@ -256,16 +301,17 @@ async def process_poem(message: Message) -> None:
                     llm_result.scores,
                     llm_result.reasons,
                     llm_result.safety_flag,
+                    llm_result.safety_status,
                 )
             except submissions_service.SubmissionExistsError:
                 pass
             gift = await get_gift_for_day(day)
-            gift_line = gift.gift_text or gift.gift_url or "Подарок пока не настроен."
+            gift_line = _format_gift_line(gift)
             await message.answer(f"{llm_result.ded_moroz_reply}\nТвой подарок: {gift_line}")
         else:
             attempts_left = settings.campaign.max_attempts_per_day - attempts - 1
             suffix = f" Осталось попыток: {attempts_left}." if attempts_left > 0 else ""
             await message.answer(f"{llm_result.ded_moroz_reply}{suffix}")
     except Exception as exc:  # noqa: BLE001
-        await log_error(SeverityLevel.ERROR, "Processing poem failed", {"error": str(exc)})
+        await log_error(SeverityLevel.ERROR, "Processing poem failed", {"error": str(exc)}, service_name="bot")
         await message.answer("Моё волшебство дало сбой. Попробуй позже.")

--- a/ded_moroz/llm/client.py
+++ b/ded_moroz/llm/client.py
@@ -7,6 +7,7 @@ import httpx
 from pydantic import BaseModel, ValidationError
 
 from ded_moroz.config import settings
+from ded_moroz.db.models import SafetyStatus
 
 DecisionLiteral = Literal["ACCEPT", "RETRY", "REJECT"]
 
@@ -17,6 +18,7 @@ class LlmResponse(BaseModel):
     scores: dict[str, Any] | None = None
     reasons: dict[str, Any] | None = None
     safety_flag: bool = False
+    safety_status: SafetyStatus = SafetyStatus.SAFE
 
 
 PROMPT_SYSTEM = (
@@ -42,6 +44,7 @@ class OpenRouterClient:
                     "scores": {"type": "object"},
                     "reasons": {"type": "object"},
                     "safety_flag": {"type": "boolean"},
+                    "safety_status": {"type": "string", "enum": [item.value for item in SafetyStatus]},
                 },
                 "required": ["decision", "ded_moroz_reply"],
                 "additionalProperties": False,

--- a/ded_moroz/migrations/versions/0002_add_missing_fields.py
+++ b/ded_moroz/migrations/versions/0002_add_missing_fields.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0002_add_missing_fields"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    safety_status_enum = sa.Enum("safe", "needs_review", "blocked", name="safetystatus")
+    safety_status_enum.create(op.get_bind(), checkfirst=True)
+
+    gift_type_enum = sa.Enum("text", "url", "payload", name="gifttype")
+    gift_type_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column("enrolled_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.add_column("users", sa.Column("paused_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("users", sa.Column("stopped_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    )
+
+    op.add_column(
+        "gifts",
+        sa.Column("gift_type", gift_type_enum, server_default="text", nullable=False),
+    )
+    op.add_column("gifts", sa.Column("payload", sa.JSON(), nullable=True))
+
+    op.add_column("poem_attempts", sa.Column("safety_status", safety_status_enum, server_default="safe", nullable=False))
+    op.add_column("submissions", sa.Column("safety_status", safety_status_enum, server_default="safe", nullable=False))
+
+    op.add_column("error_logs", sa.Column("service_name", sa.String(length=255), nullable=True))
+
+    op.add_column(
+        "service_heartbeats",
+        sa.Column("beat_interval_seconds", sa.Integer(), server_default="600", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("service_heartbeats", "beat_interval_seconds")
+
+    op.drop_column("error_logs", "service_name")
+
+    op.drop_column("submissions", "safety_status")
+    op.drop_column("poem_attempts", "safety_status")
+
+    op.drop_column("gifts", "payload")
+    op.drop_column("gifts", "gift_type")
+
+    op.drop_column("users", "last_seen_at")
+    op.drop_column("users", "stopped_at")
+    op.drop_column("users", "paused_at")
+    op.drop_column("users", "enrolled_at")
+
+    sa.Enum(name="gifttype").drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name="safetystatus").drop(op.get_bind(), checkfirst=True)

--- a/ded_moroz/scheduler.py
+++ b/ded_moroz/scheduler.py
@@ -26,7 +26,7 @@ async def missed_job(bot: Bot) -> None:
 
 
 async def heartbeat_job() -> None:
-    await beat("scheduler")
+    await beat("scheduler", interval_seconds=600)
 
 
 async def main() -> None:

--- a/ded_moroz/services/admin_notifications.py
+++ b/ded_moroz/services/admin_notifications.py
@@ -16,7 +16,8 @@ async def dispatch_admin_errors(bot: Bot) -> int:
     sent = 0
     for item in pending:
         error = item.error
-        message = f"[ERROR] {error.level}: {error.message}\nContext: {error.context}"
+        service_info = f"[{error.service_name}]" if error.service_name else ""
+        message = f"[ERROR]{service_info} {error.level}: {error.message}\nContext: {error.context}"
         for admin_id in admins:
             await bot.send_message(admin_id, message)
             sent += 1

--- a/ded_moroz/services/gifts.py
+++ b/ded_moroz/services/gifts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlalchemy import select
 
-from ded_moroz.db.models import Gift
+from ded_moroz.db.models import Gift, GiftType
 from ded_moroz.db.session import session_scope
 
 
@@ -12,13 +12,21 @@ async def get_gift_for_day(day: int) -> Gift | None:
         return result.scalar_one_or_none()
 
 
-async def set_gift(day: int, gift_text: str | None = None, gift_url: str | None = None) -> Gift:
+async def set_gift(
+    day: int,
+    gift_type: GiftType = GiftType.TEXT,
+    gift_text: str | None = None,
+    gift_url: str | None = None,
+    payload: dict | None = None,
+) -> Gift:
     async with session_scope() as session:
         result = await session.execute(select(Gift).where(Gift.day == day))
         gift = result.scalar_one_or_none()
         if gift is None:
             gift = Gift(day=day)
             session.add(gift)
+        gift.gift_type = gift_type
         gift.gift_text = gift_text
         gift.gift_url = gift_url
+        gift.payload = payload
         return gift

--- a/ded_moroz/services/heartbeat.py
+++ b/ded_moroz/services/heartbeat.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 
@@ -8,13 +8,19 @@ from ded_moroz.db.models import ServiceHeartbeat
 from ded_moroz.db.session import session_scope
 
 
-async def beat(service_name: str) -> ServiceHeartbeat:
+async def beat(service_name: str, interval_seconds: int | None = None) -> ServiceHeartbeat:
     async with session_scope() as session:
         result = await session.execute(select(ServiceHeartbeat).where(ServiceHeartbeat.service_name == service_name))
         heartbeat = result.scalar_one_or_none()
         if heartbeat is None:
-            heartbeat = ServiceHeartbeat(service_name=service_name, last_beat_at=datetime.utcnow())
+            heartbeat = ServiceHeartbeat(
+                service_name=service_name,
+                last_beat_at=datetime.now(timezone.utc),
+                beat_interval_seconds=interval_seconds or 600,
+            )
             session.add(heartbeat)
         else:
-            heartbeat.last_beat_at = datetime.utcnow()
+            heartbeat.last_beat_at = datetime.now(timezone.utc)
+            if interval_seconds is not None:
+                heartbeat.beat_interval_seconds = interval_seconds
         return heartbeat

--- a/ded_moroz/services/logging.py
+++ b/ded_moroz/services/logging.py
@@ -13,9 +13,11 @@ from ded_moroz.db.session import session_scope
 logger = logging.getLogger(__name__)
 
 
-async def log_error(level: SeverityLevel, message: str, context: dict[str, Any] | None = None) -> ErrorLog:
+async def log_error(
+    level: SeverityLevel, message: str, context: dict[str, Any] | None = None, service_name: str | None = None
+) -> ErrorLog:
     async with session_scope() as session:
-        record = ErrorLog(level=level, message=message, context=context)
+        record = ErrorLog(level=level, message=message, context=context, service_name=service_name)
         session.add(record)
         await session.flush()
 

--- a/ded_moroz/services/notifications.py
+++ b/ded_moroz/services/notifications.py
@@ -30,9 +30,14 @@ async def send_daily_reminders(bot: Bot) -> None:
             try:
                 await bot.send_message(user.telegram_id, f"День {day}! Не забудь прислать стих для подарка.")
             except Exception as exc:  # noqa: BLE001
-                await log_error(SeverityLevel.ERROR, "Failed to send reminder", {"user_id": user.id, "error": str(exc)})
+                await log_error(
+                    SeverityLevel.ERROR,
+                    "Failed to send reminder",
+                    {"user_id": user.id, "error": str(exc)},
+                    service_name="scheduler",
+                )
         offset += len(users)
-    await beat("scheduler")
+    await beat("scheduler", interval_seconds=24 * 60 * 60)
 
 
 async def send_missed_notifications(bot: Bot) -> None:
@@ -67,6 +72,7 @@ async def send_missed_notifications(bot: Bot) -> None:
                     SeverityLevel.ERROR,
                     "Failed to send missed notification",
                     {"user_id": user.id, "error": str(exc)},
+                    service_name="scheduler",
                 )
         offset += len(users)
-    await beat("scheduler")
+    await beat("scheduler", interval_seconds=24 * 60 * 60)

--- a/ded_moroz/services/submissions.py
+++ b/ded_moroz/services/submissions.py
@@ -5,7 +5,15 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
-from ded_moroz.db.models import NotificationLog, NotificationType, PoemAttempt, Submission, User, UserStatus
+from ded_moroz.db.models import (
+    NotificationLog,
+    NotificationType,
+    PoemAttempt,
+    SafetyStatus,
+    Submission,
+    User,
+    UserStatus,
+)
 from ded_moroz.db.session import session_scope
 
 
@@ -34,6 +42,7 @@ async def record_attempt(
     scores: dict[str, Any] | None,
     reasons: dict[str, Any] | None,
     safety_flag: bool,
+    safety_status: SafetyStatus,
 ) -> PoemAttempt:
     async with session_scope() as session:
         attempt = PoemAttempt(
@@ -45,6 +54,7 @@ async def record_attempt(
             scores=scores,
             reasons=reasons,
             safety_flag=safety_flag,
+            safety_status=safety_status,
         )
         session.add(attempt)
         return attempt
@@ -59,6 +69,7 @@ async def save_submission(
     scores: dict[str, Any] | None,
     reasons: dict[str, Any] | None,
     safety_flag: bool,
+    safety_status: SafetyStatus,
 ) -> Submission:
     async with session_scope() as session:
         submission = Submission(
@@ -70,6 +81,7 @@ async def save_submission(
             scores=scores,
             reasons=reasons,
             safety_flag=safety_flag,
+            safety_status=safety_status,
         )
         session.add(submission)
         try:

--- a/ded_moroz/services/users.py
+++ b/ded_moroz/services/users.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from sqlalchemy import select
 
 from ded_moroz.db.models import User, UserStatus
@@ -17,12 +19,14 @@ async def get_or_create_user(telegram_id: int, username: str | None, first_name:
                 first_name=first_name,
                 last_name=last_name,
                 status=UserStatus.ACTIVE,
+                last_seen_at=datetime.now(timezone.utc),
             )
             session.add(user)
         else:
             user.username = username
             user.first_name = first_name
             user.last_name = last_name
+            user.last_seen_at = datetime.now(timezone.utc)
         return user
 
 
@@ -31,12 +35,24 @@ async def update_status(user_id: int, status: UserStatus) -> None:
         user = await session.get(User, user_id)
         if user:
             user.status = status
+            now = datetime.now(timezone.utc)
+            if status == UserStatus.PAUSED:
+                user.paused_at = now
+            elif status == UserStatus.STOPPED:
+                user.stopped_at = now
+            elif status == UserStatus.ACTIVE:
+                user.paused_at = None
+                user.stopped_at = None
+            user.last_seen_at = now
 
 
 async def get_user_by_telegram(telegram_id: int) -> User | None:
     async with session_scope() as session:
         result = await session.execute(select(User).where(User.telegram_id == telegram_id))
-        return result.scalar_one_or_none()
+        user = result.scalar_one_or_none()
+        if user:
+            user.last_seen_at = datetime.now(timezone.utc)
+        return user
 
 
 async def list_active_users(limit: int, offset: int = 0) -> list[User]:

--- a/tests/test_llm_validation.py
+++ b/tests/test_llm_validation.py
@@ -39,6 +39,7 @@ async def test_llm_valid_json(monkeypatch: pytest.MonkeyPatch, engine) -> None: 
         "scores": {"rhyme": 1},
         "reasons": {"tone": "ok"},
         "safety_flag": False,
+        "safety_status": "safe",
     }
     payload = {"choices": [{"message": {"content": json.dumps(content)}}]}
 

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -4,6 +4,7 @@ import pytest
 
 from ded_moroz.services.submissions import SubmissionExistsError, save_submission
 from ded_moroz.services.users import get_or_create_user
+from ded_moroz.db.models import SafetyStatus
 
 
 @pytest.mark.asyncio
@@ -18,6 +19,7 @@ async def test_submission_unique(engine) -> None:  # noqa: ARG001
         scores=None,
         reasons=None,
         safety_flag=False,
+        safety_status=SafetyStatus.SAFE,
     )
     with pytest.raises(SubmissionExistsError):
         await save_submission(
@@ -29,4 +31,5 @@ async def test_submission_unique(engine) -> None:  # noqa: ARG001
             scores=None,
             reasons=None,
             safety_flag=False,
+            safety_status=SafetyStatus.SAFE,
         )


### PR DESCRIPTION
## Summary
- add new database enums/columns for user timestamps, gift type/payload, safety status, error sources, and heartbeat intervals with an Alembic migration
- propagate safety status and heartbeat interval handling through services and handlers, including enriched admin displays and last-seen tracking
- extend gift management to accept types/payloads and adjust LLM schema/tests for new safety metadata

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c51d976d88320b4e0fc2c82fef97d)