### PR TITLE
Add CTA flow and submission deadline handling

### DIFF
--- a/ded_moroz/handlers/commands.py
+++ b/ded_moroz/handlers/commands.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from aiogram import F, Router
 from aiogram.filters import Command, CommandObject
-from aiogram.types import Message
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 import json
 
@@ -14,7 +14,14 @@ from ded_moroz.services import submissions as submissions_service
 from ded_moroz.services.gifts import get_gift_for_day, set_gift
 from ded_moroz.services.logging import log_error
 from ded_moroz.services.users import get_or_create_user, get_user_by_telegram, update_status
-from ded_moroz.utils.time import current_campaign_day, is_before_start, is_campaign_active
+from ded_moroz.utils.time import (
+    current_day_deadline,
+    is_after_deadline,
+    is_before_start,
+    is_campaign_active,
+    is_quiet_hours,
+    quiet_hours_end,
+)
 
 router = Router()
 llm_client = OpenRouterClient()
@@ -34,6 +41,40 @@ def _format_gift_line(gift: object) -> str:
     return "Подарок пока не настроен."
 
 
+def _main_keyboard(user_status: UserStatus) -> InlineKeyboardMarkup:
+    inline_keyboard = [
+        [InlineKeyboardButton(text="Сдать стих за сегодня", callback_data="gift:submit")],
+        [InlineKeyboardButton(text="Статус", callback_data="status:show")],
+    ]
+    if user_status == UserStatus.PAUSED:
+        inline_keyboard.append([InlineKeyboardButton(text="Продолжить", callback_data="user:resume")])
+    else:
+        inline_keyboard.append([InlineKeyboardButton(text="Пауза", callback_data="user:pause")])
+    inline_keyboard.append([InlineKeyboardButton(text="Остановить", callback_data="user:stop_confirm")])
+    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
+
+
+def _stop_confirmation_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="Да, остановить", callback_data="user:stop"),
+                InlineKeyboardButton(text="Отмена", callback_data="user:stop_cancel"),
+            ]
+        ]
+    )
+
+
+async def _respond(target: Message | CallbackQuery, text: str, reply_markup: InlineKeyboardMarkup | None = None) -> None:
+    if isinstance(target, CallbackQuery):
+        await target.answer()
+        message = target.message
+    else:
+        message = target
+    if message:
+        await message.answer(text, reply_markup=reply_markup)
+
+
 @router.message(Command("start"))
 async def cmd_start(message: Message) -> None:
     user = await get_or_create_user(
@@ -42,9 +83,14 @@ async def cmd_start(message: Message) -> None:
         first_name=message.from_user.first_name,
         last_name=message.from_user.last_name,
     )
+    if user.status == UserStatus.STOPPED:
+        await update_status(user.id, UserStatus.ACTIVE)
+        user.status = UserStatus.ACTIVE
+    keyboard = _main_keyboard(user.status)
     await message.answer(
         "Хо-хо-хо! Ты в игре. Каждый день жду твой стих, чтобы открыть подарок. "
-        "Пиши текстом, а я проверю через волшебство ИИ."
+        "Пиши текстом, а я проверю через волшебство ИИ.",
+        reply_markup=keyboard,
     )
 
 
@@ -55,7 +101,7 @@ async def cmd_pause(message: Message) -> None:
         await message.answer("Сначала нажми /start, чтобы присоединиться.")
         return
     await update_status(user.id, UserStatus.PAUSED)
-    await message.answer("Понял, делаю паузу. Возвращайся, когда будешь готов.")
+    await message.answer("Понял, делаю паузу. Возвращайся, когда будешь готов.", reply_markup=_main_keyboard(UserStatus.PAUSED))
 
 
 @router.message(Command("resume"))
@@ -65,7 +111,7 @@ async def cmd_resume(message: Message) -> None:
         await message.answer("Сначала нажми /start, чтобы присоединиться.")
         return
     await update_status(user.id, UserStatus.ACTIVE)
-    await message.answer("Продолжаем! Снова жду твои стихи.")
+    await message.answer("Продолжаем! Снова жду твои стихи.", reply_markup=_main_keyboard(UserStatus.ACTIVE))
 
 
 @router.message(Command("stop"))
@@ -74,8 +120,7 @@ async def cmd_stop(message: Message) -> None:
     if not user:
         await message.answer("Ты ещё не в игре. Нажми /start.")
         return
-    await update_status(user.id, UserStatus.STOPPED)
-    await message.answer("Жаль расставаться. Если передумаешь — /start." )
+    await message.answer("Точно остановить участие? Ты перестанешь получать уведомления.", reply_markup=_stop_confirmation_keyboard())
 
 
 @router.message(Command("status"))
@@ -84,7 +129,7 @@ async def cmd_status(message: Message) -> None:
     if not user:
         await message.answer("Я тебя ещё не видел. /start, чтобы начать.")
         return
-    await message.answer(format_status(user))
+    await message.answer(format_status(user), reply_markup=_main_keyboard(user.status))
 
 
 @router.message(Command("admin_stats"))
@@ -245,6 +290,125 @@ async def cmd_admin_health(message: Message) -> None:
     await message.answer("\n".join(lines))
 
 
+@router.callback_query(F.data == "status:show")
+async def cq_status(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    if not user:
+        await _respond(callback, "Я тебя ещё не видел. Нажми /start, чтобы начать.")
+        return
+    await _respond(callback, format_status(user), reply_markup=_main_keyboard(user.status))
+
+
+@router.message(Command("gift"))
+async def cmd_gift(message: Message) -> None:
+    await _handle_gift_request(message)
+
+
+@router.callback_query(F.data == "gift:submit")
+async def cq_gift(callback: CallbackQuery) -> None:
+    await _handle_gift_request(callback)
+
+
+async def _handle_gift_request(target: Message | CallbackQuery) -> None:
+    user = await get_user_by_telegram(target.from_user.id)
+    if not user:
+        await _respond(target, "Сначала нажми /start, чтобы присоединиться.")
+        return
+    if user.status == UserStatus.STOPPED:
+        await _respond(target, "Ты остановил участие. Вернись командой /start.")
+        return
+    if user.status == UserStatus.PAUSED:
+        await _respond(target, "Ты на паузе. /resume — и снова в бой.", reply_markup=_main_keyboard(user.status))
+        return
+    if is_before_start():
+        await _respond(target, "Кампания ещё не началась. Потерпи чуть-чуть!")
+        return
+    if not is_campaign_active():
+        await _respond(target, "Кампания уже завершилась. Спасибо за участие!")
+        return
+    if is_quiet_hours():
+        quiet_end = quiet_hours_end()
+        await _respond(
+            target,
+            f"Сейчас тихие часы. Жду твой стих после {quiet_end.strftime('%d.%m %H:%M %Z')}.",
+        )
+        return
+
+    day, deadline_dt = current_day_deadline()
+    if is_after_deadline():
+        await _respond(
+            target,
+            f"Дедлайн на сегодня ({deadline_dt.strftime('%H:%M %Z')}) уже прошёл. Жду тебя завтра!",
+        )
+        return
+
+    if await submissions_service.has_submission(user.id, day):
+        gift = await get_gift_for_day(day)
+        gift_line = _format_gift_line(gift)
+        await _respond(target, f"На сегодня всё! {gift_line}")
+        return
+
+    attempts = await submissions_service.count_attempts(user.id, day)
+    if attempts >= settings.campaign.max_attempts_per_day:
+        await _respond(target, "Лимит попыток на сегодня исчерпан. Приходи завтра.")
+        return
+    attempts_left = settings.campaign.max_attempts_per_day - attempts
+    attempts_hint = (
+        f" Осталось попыток: {attempts_left}." if attempts_left < settings.campaign.max_attempts_per_day else ""
+    )
+    await _respond(
+        target,
+        f"День {day}. Присылай стих текстом, чтобы открыть подарок. Дедлайн сегодня: {deadline_dt.strftime('%H:%M %Z')}."
+        f"{attempts_hint}",
+    )
+
+
+@router.callback_query(F.data == "user:pause")
+async def cq_pause(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    if not user:
+        await _respond(callback, "Сначала нажми /start, чтобы присоединиться.")
+        return
+    await update_status(user.id, UserStatus.PAUSED)
+    await _respond(callback, "Понял, делаю паузу. Возвращайся, когда будешь готов.", reply_markup=_main_keyboard(UserStatus.PAUSED))
+
+
+@router.callback_query(F.data == "user:resume")
+async def cq_resume(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    if not user:
+        await _respond(callback, "Сначала нажми /start, чтобы присоединиться.")
+        return
+    await update_status(user.id, UserStatus.ACTIVE)
+    await _respond(callback, "Продолжаем! Снова жду твои стихи.", reply_markup=_main_keyboard(UserStatus.ACTIVE))
+
+
+@router.callback_query(F.data == "user:stop_confirm")
+async def cq_stop_confirm(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    if not user:
+        await _respond(callback, "Ты ещё не в игре. Нажми /start.")
+        return
+    await _respond(callback, "Точно остановить участие? Ты перестанешь получать уведомления.", reply_markup=_stop_confirmation_keyboard())
+
+
+@router.callback_query(F.data == "user:stop")
+async def cq_stop(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    if not user:
+        await _respond(callback, "Ты ещё не в игре. Нажми /start.")
+        return
+    await update_status(user.id, UserStatus.STOPPED)
+    await _respond(callback, "Жаль расставаться. Если передумаешь — /start.")
+
+
+@router.callback_query(F.data == "user:stop_cancel")
+async def cq_stop_cancel(callback: CallbackQuery) -> None:
+    user = await get_user_by_telegram(callback.from_user.id)
+    status = user.status if user else UserStatus.ACTIVE
+    await _respond(callback, "Отмена. Я с тобой!", reply_markup=_main_keyboard(status))
+
+
 @router.message(F.text)
 async def process_poem(message: Message) -> None:
     user = await get_user_by_telegram(message.from_user.id)
@@ -263,8 +427,16 @@ async def process_poem(message: Message) -> None:
     if not is_campaign_active():
         await message.answer("Кампания уже завершилась. Спасибо за участие!")
         return
+    if is_quiet_hours():
+        quiet_end = quiet_hours_end()
+        await message.answer(f"Сейчас тихие часы. Жду стих после {quiet_end.strftime('%d.%m %H:%M %Z')}.")
+        return
 
-    day = current_campaign_day()
+    day, deadline_dt = current_day_deadline()
+    if is_after_deadline():
+        await message.answer(f"Дедлайн на сегодня ({deadline_dt.strftime('%H:%M %Z')}) уже прошёл. Жду тебя завтра!")
+        return
+
     if await submissions_service.has_submission(user.id, day):
         gift = await get_gift_for_day(day)
         gift_line = _format_gift_line(gift)

--- a/ded_moroz/handlers/helpers.py
+++ b/ded_moroz/handlers/helpers.py
@@ -2,6 +2,15 @@ from __future__ import annotations
 
 from ded_moroz.config import settings
 from ded_moroz.db.models import User, UserStatus
+from ded_moroz.utils.time import (
+    current_campaign_day,
+    current_day_deadline,
+    is_before_start,
+    is_campaign_active,
+    is_quiet_hours,
+    now,
+    quiet_hours_end,
+)
 
 
 def is_admin(telegram_id: int) -> bool:
@@ -9,10 +18,36 @@ def is_admin(telegram_id: int) -> bool:
 
 
 def format_status(user: User) -> str:
+    current_dt = now()
+    is_enrolled = user.status != UserStatus.STOPPED
+    is_paused = user.status == UserStatus.PAUSED
+    if is_campaign_active(current_dt):
+        campaign_state = "идёт"
+    elif is_before_start(current_dt):
+        campaign_state = "ещё не началась"
+    else:
+        campaign_state = "завершилась"
+    day = current_campaign_day(current_dt, clamp=True)
+    _, deadline_dt = current_day_deadline(current_dt)
+    quiet_hours_pause = quiet_hours_end(current_dt) if is_quiet_hours(current_dt) else None
+
+    if is_paused:
+        pause_until = "Пауза до возобновления (/resume)"
+    elif quiet_hours_pause:
+        pause_until = quiet_hours_pause.strftime("%d.%m %H:%M %Z")
+    else:
+        pause_until = "—"
+
     lines = [
         f"ID: {user.telegram_id}",
         f"Статус: {user.status.value}",
+        f"Записан: {'да' if is_enrolled else 'нет'}",
+        f"На паузе: {'да' if is_paused else 'нет'}",
+        f"Пауза до: {pause_until}",
         f"Имя: {(user.first_name or '').strip()} {(user.last_name or '').strip()}",
         f"Юзернейм: @{user.username}" if user.username else "Юзернейм: —",
+        f"День кампании: {day}/{settings.campaign.days}",
+        f"Дедлайн сегодня: {deadline_dt.strftime('%H:%M %Z')}",
+        f"Кампания: {campaign_state}",
     ]
     return "\n".join(lines)

--- a/ded_moroz/utils/time.py
+++ b/ded_moroz/utils/time.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
+from datetime import datetime, time, timedelta
 from zoneinfo import ZoneInfo
 
 from ded_moroz.config import settings
@@ -10,21 +10,32 @@ def now() -> datetime:
     return datetime.now(ZoneInfo(settings.campaign.timezone))
 
 
-def current_campaign_day(current: datetime | None = None) -> int:
+def campaign_start_datetime() -> datetime:
+    return datetime.combine(settings.campaign.start_date, time(0, 0), tzinfo=ZoneInfo(settings.campaign.timezone))
+
+
+def campaign_end_datetime() -> datetime:
+    return campaign_start_datetime() + timedelta(days=settings.campaign.days)
+
+
+def current_campaign_day(current: datetime | None = None, clamp: bool = True) -> int:
     current_dt = current or now()
-    start_date = settings.campaign.start_date
-    delta = current_dt.date() - start_date
-    return delta.days + 1
+    start_dt = campaign_start_datetime()
+    delta = current_dt - start_dt
+    day = delta.days + 1
+    if not clamp:
+        return day
+    return max(1, min(settings.campaign.days, day))
 
 
 def is_campaign_active(current: datetime | None = None) -> bool:
-    day = current_campaign_day(current)
-    return 1 <= day <= settings.campaign.days
+    current_dt = current or now()
+    return campaign_start_datetime() <= current_dt < campaign_end_datetime()
 
 
 def is_before_start(current: datetime | None = None) -> bool:
     current_dt = current or now()
-    return current_dt.date() < settings.campaign.start_date
+    return current_dt < campaign_start_datetime()
 
 
 def reminder_window(current: datetime | None = None) -> bool:
@@ -37,21 +48,56 @@ def missed_window(current: datetime | None = None) -> bool:
     return current_dt.time().hour >= settings.campaign.missed_deadline_hour
 
 
-def is_quiet_hours(current: datetime | None = None) -> bool:
-    current_dt = current or now()
+def quiet_hours_window(current: datetime | None = None) -> tuple[datetime, datetime]:
+    current_dt = (current or now()).astimezone(ZoneInfo(settings.campaign.timezone))
     start = settings.campaign.quiet_hours_start
     end = settings.campaign.quiet_hours_end
-    hour = current_dt.time().hour
+    start_dt = datetime.combine(current_dt.date(), time(start, 0), tzinfo=current_dt.tzinfo)
+    end_dt = datetime.combine(current_dt.date(), time(end, 0), tzinfo=current_dt.tzinfo)
 
     if start == end:
+        return start_dt, start_dt
+    if end <= start:
+        end_dt += timedelta(days=1)
+    return start_dt, end_dt
+
+
+def quiet_hours_end(current: datetime | None = None) -> datetime:
+    current_dt = (current or now()).astimezone(ZoneInfo(settings.campaign.timezone))
+    start_dt, end_dt = quiet_hours_window(current_dt)
+    if current_dt < start_dt:
+        return start_dt
+    return end_dt
+
+
+def is_quiet_hours(current: datetime | None = None) -> bool:
+    current_dt = (current or now()).astimezone(ZoneInfo(settings.campaign.timezone))
+    start_dt, end_dt = quiet_hours_window(current_dt)
+    if start_dt == end_dt:
         return False
-    if start < end:
-        return start <= hour < end
-    return hour >= start or hour < end
+    return start_dt <= current_dt < end_dt
+
+
+def day_deadline(day: int, deadline_hour: int | None = None) -> datetime:
+    tz = ZoneInfo(settings.campaign.timezone)
+    hour = deadline_hour if deadline_hour is not None else settings.campaign.missed_deadline_hour
+    base_date = settings.campaign.start_date + timedelta(days=day - 1)
+    return datetime.combine(base_date, time(hour, 0), tzinfo=tz)
+
+
+def current_day_deadline(current: datetime | None = None) -> tuple[int, datetime]:
+    current_dt = current or now()
+    day = current_campaign_day(current_dt, clamp=True)
+    return day, day_deadline(day)
+
+
+def is_after_deadline(current: datetime | None = None) -> bool:
+    current_dt = current or now()
+    _, deadline_dt = current_day_deadline(current_dt)
+    return current_dt >= deadline_dt
 
 
 def day_bounds(target_day: int) -> tuple[datetime, datetime]:
-    tz = ZoneInfo(settings.campaign.timezone)
-    start = datetime.combine(settings.campaign.start_date + timedelta(days=target_day - 1), time(0, 0), tzinfo=tz)
+    start = campaign_start_datetime() + timedelta(days=target_day - 1)
     end = start + timedelta(days=1)
     return start, end


### PR DESCRIPTION
## Summary
- add inline CTA keyboard for start/status, confirmation for stop, and pause/resume callbacks
- add /gift handler plus submission guards for quiet hours and daily deadlines
- expand time utilities and status output with enrollment flags and campaign timing details

## Testing
- pytest (fails: ModuleNotFoundError: No module named 'sqlalchemy')

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c558c3b44832083ccd006c8b20e05)