### PR TITLE
Add poem input validation and harden LLM client

### DIFF
--- a/ded_moroz/handlers/commands.py
+++ b/ded_moroz/handlers/commands.py
@@ -5,11 +5,12 @@ from aiogram.filters import Command, CommandObject
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
 
 import json
+from typing import Final
 
 from ded_moroz.config import settings
 from ded_moroz.db.models import GiftType, SeverityLevel, UserStatus
 from ded_moroz.handlers.helpers import format_status, is_admin
-from ded_moroz.llm.client import LlmResponse, OpenRouterClient
+from ded_moroz.llm.client import LlmClientError, LlmResponse, OpenRouterClient
 from ded_moroz.services import submissions as submissions_service
 from ded_moroz.services.gifts import get_gift_for_day, set_gift
 from ded_moroz.services.logging import log_error
@@ -22,6 +23,9 @@ from ded_moroz.utils.time import (
     is_quiet_hours,
     quiet_hours_end,
 )
+
+POEM_MIN_LENGTH: Final[int] = 10
+POEM_MAX_LENGTH: Final[int] = 1500
 
 router = Router()
 llm_client = OpenRouterClient()
@@ -449,6 +453,25 @@ async def process_poem(message: Message) -> None:
         return
 
     poem_text = message.text
+    if not isinstance(poem_text, str):
+        await message.answer("Я жду текстовое сообщение со стихом. Голосовые и вложения не подойдут.")
+        return
+    poem_text = poem_text.strip()
+    if len(poem_text) < POEM_MIN_LENGTH:
+        attempts_left = settings.campaign.max_attempts_per_day - attempts
+        suffix = f" Попыток осталось: {attempts_left}." if attempts_left else ""
+        await message.answer(
+            f"Стих слишком короткий — добавь деталей и эмоций (минимум {POEM_MIN_LENGTH} символов).{suffix}"
+        )
+        return
+    if len(poem_text) > POEM_MAX_LENGTH:
+        attempts_left = settings.campaign.max_attempts_per_day - attempts
+        suffix = f" Попыток осталось: {attempts_left}." if attempts_left else ""
+        await message.answer(
+            f"Стих слишком длинный — уложись в {POEM_MAX_LENGTH} символов и пришли снова.{suffix}"
+        )
+        return
+
     try:
         llm_result: LlmResponse = await llm_client.evaluate_poem(poem_text, day, user.id)
         await submissions_service.record_attempt(
@@ -484,6 +507,14 @@ async def process_poem(message: Message) -> None:
             attempts_left = settings.campaign.max_attempts_per_day - attempts - 1
             suffix = f" Осталось попыток: {attempts_left}." if attempts_left > 0 else ""
             await message.answer(f"{llm_result.ded_moroz_reply}{suffix}")
+    except LlmClientError as exc:
+        await log_error(
+            SeverityLevel.ERROR,
+            "LLM evaluation failed",
+            {"error": str(exc), "user_id": user.id, "day": day},
+            service_name="bot",
+        )
+        await message.answer("Моё волшебство сегодня не отвечает. Попробуй позже — попытка не сгорела.")
     except Exception as exc:  # noqa: BLE001
         await log_error(SeverityLevel.ERROR, "Processing poem failed", {"error": str(exc)}, service_name="bot")
         await message.answer("Моё волшебство дало сбой. Попробуй позже.")

--- a/ded_moroz/llm/client.py
+++ b/ded_moroz/llm/client.py
@@ -21,10 +21,68 @@ class LlmResponse(BaseModel):
     safety_status: SafetyStatus = SafetyStatus.SAFE
 
 
+class LlmClientError(Exception):
+    """Raised when the LLM client fails to return a valid response."""
+
+
 PROMPT_SYSTEM = (
     "Ты — строгий, но добрый Дед Мороз, проверяющий новогодние стихи. "
     "Отвечай саркастично, но без оскорблений. Возвращай JSON согласно схеме."
 )
+
+
+LLM_JSON_SCHEMA = {
+    "name": "PoemDecision",
+    "strict": True,
+    "schema": {
+        "type": "object",
+        "properties": {
+            "decision": {"type": "string", "enum": ["ACCEPT", "RETRY", "REJECT"]},
+            "ded_moroz_reply": {"type": "string"},
+            "scores": {"type": "object"},
+            "reasons": {"type": "object"},
+            "safety_flag": {"type": "boolean"},
+            "safety_status": {"type": "string", "enum": [item.value for item in SafetyStatus]},
+        },
+        "required": ["decision", "ded_moroz_reply"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _extract_payload(data: dict[str, Any]) -> dict[str, Any]:
+    try:
+        message = data["choices"][0]["message"]
+    except (KeyError, IndexError, TypeError) as exc:  # pragma: no cover - defensive
+        raise LlmClientError("Malformed LLM response: missing message") from exc
+
+    if not message:
+        raise LlmClientError("Malformed LLM response: empty message")
+
+    if isinstance(message, dict) and message.get("parsed"):
+        parsed = message["parsed"]
+        if not isinstance(parsed, dict):
+            raise LlmClientError("Malformed LLM response: `parsed` must be an object")
+        return parsed
+
+    content = message.get("content") if isinstance(message, dict) else None
+
+    if isinstance(content, list):
+        content = "".join(part.get("text", "") for part in content if isinstance(part, dict)).strip() or None
+
+    if isinstance(content, dict):
+        payload = content
+    elif isinstance(content, str):
+        try:
+            payload = json.loads(content)
+        except json.JSONDecodeError as exc:  # pragma: no cover - parsing guard
+            raise LlmClientError("Malformed LLM response: invalid JSON content") from exc
+    else:
+        raise LlmClientError("Malformed LLM response: empty content")
+
+    if not isinstance(payload, dict):
+        raise LlmClientError("Malformed LLM response: payload must be an object")
+    return payload
 
 
 class OpenRouterClient:
@@ -34,26 +92,9 @@ class OpenRouterClient:
         self.model = model or settings.openrouter.model
 
     async def evaluate_poem(self, poem: str, day: int, user_id: int) -> LlmResponse:
-        schema = {
-            "name": "PoemDecision",
-            "schema": {
-                "type": "object",
-                "properties": {
-                    "decision": {"type": "string", "enum": ["ACCEPT", "RETRY", "REJECT"]},
-                    "ded_moroz_reply": {"type": "string"},
-                    "scores": {"type": "object"},
-                    "reasons": {"type": "object"},
-                    "safety_flag": {"type": "boolean"},
-                    "safety_status": {"type": "string", "enum": [item.value for item in SafetyStatus]},
-                },
-                "required": ["decision", "ded_moroz_reply"],
-                "additionalProperties": False,
-            },
-            "strict": True,
-        }
         payload = {
             "model": self.model,
-            "response_format": {"type": "json_schema", "json_schema": schema},
+            "response_format": {"type": "json_schema", "json_schema": LLM_JSON_SCHEMA},
             "messages": [
                 {"role": "system", "content": PROMPT_SYSTEM},
                 {
@@ -68,15 +109,20 @@ class OpenRouterClient:
             "HTTP-Referer": "https://openrouter.ai/",
             "X-Title": "Ded Moroz Advent Bot",
         }
-        async with httpx.AsyncClient() as client:
-            response = await client.post(f"{self.base_url}/chat/completions", headers=headers, json=payload, timeout=60)
-            response.raise_for_status()
-            data = response.json()
-        content = data.get("choices", [{}])[0].get("message", {}).get("content")
-        if not content:
-            raise ValueError("Empty response from LLM")
         try:
-            parsed = json.loads(content)
-            return LlmResponse.model_validate(parsed)
-        except (json.JSONDecodeError, ValidationError) as exc:
-            raise ValueError("LLM response validation failed") from exc
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    f"{self.base_url}/chat/completions", headers=headers, json=payload, timeout=60
+                )
+                response.raise_for_status()
+                data = response.json()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - network errors
+            raise LlmClientError("LLM request failed with HTTP error") from exc
+        except httpx.RequestError as exc:  # pragma: no cover - network errors
+            raise LlmClientError("LLM request failed") from exc
+
+        try:
+            parsed_payload = _extract_payload(data)
+            return LlmResponse.model_validate(parsed_payload)
+        except (ValidationError, LlmClientError) as exc:
+            raise LlmClientError("LLM response validation failed") from exc

--- a/tests/test_llm_validation.py
+++ b/tests/test_llm_validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import pytest
 
-from ded_moroz.llm.client import LlmResponse, OpenRouterClient
+from ded_moroz.llm.client import LlmClientError, LlmResponse, OpenRouterClient
 
 
 class DummyResponse:
@@ -57,5 +57,5 @@ async def test_llm_invalid_json(monkeypatch: pytest.MonkeyPatch, engine) -> None
     client = OpenRouterClient()
     monkeypatch.setattr("httpx.AsyncClient", lambda: DummyClient(payload))
 
-    with pytest.raises(ValueError):
+    with pytest.raises(LlmClientError):
         await client.evaluate_poem("Стих", day=1, user_id=1)


### PR DESCRIPTION
## Summary
- add poem input length/type validation with clearer user messaging and attempt hints
- harden LLM schema, parsing, and error handling with structured exceptions
- log LLM failures for admin alerts and update tests for the new client behavior

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd92bbe4083209b8b66d61b0a117e)