### PR TITLE
Enhance admin gift tooling and campaign date controls

### DIFF
--- a/ded_moroz/config.py
+++ b/ded_moroz/config.py
@@ -69,7 +69,15 @@ class DatabaseConfig(BaseSettings):
 class AdminConfig(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_prefix="ADMIN_", extra="ignore")
 
-    admin_ids: List[int] = Field(default_factory=list, alias="IDS")
+    admin_ids: List[int] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices(
+            "IDS",            # стандартный alias с префиксом ADMIN_
+            "ADMIN_IDS",      # без префикса (часто задавали так)
+            "ADMINS__IDS",    # вложенный синтаксис pydantic settings
+            "ADMIN_ADMIN_IDS" # префикс + имя поля
+        ),
+    )
 
     @field_validator("admin_ids", mode="before")
     @classmethod

--- a/ded_moroz/config.py
+++ b/ded_moroz/config.py
@@ -81,9 +81,11 @@ class AdminConfig(BaseSettings):
 
     @field_validator("admin_ids", mode="before")
     @classmethod
-    def _split_ids(cls, value: str | list[int]) -> list[int]:
+    def _split_ids(cls, value: str | list[int] | int) -> list[int]:
         if isinstance(value, list):
             return value
+        if isinstance(value, int):
+            return [value]
         if not value:
             return []
         return [int(item.strip()) for item in value.split(",") if item.strip()]

--- a/ded_moroz/handlers/commands.py
+++ b/ded_moroz/handlers/commands.py
@@ -1,26 +1,30 @@
 from __future__ import annotations
 
+import json
+import os
+from datetime import date
+from typing import Final
+
 from aiogram import F, Router
 from aiogram.filters import Command, CommandObject
 from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
-
-import json
-from typing import Final
 
 from ded_moroz.config import settings
 from ded_moroz.db.models import GiftType, SeverityLevel, UserStatus
 from ded_moroz.handlers.helpers import format_status, is_admin
 from ded_moroz.llm.client import LlmClientError, LlmResponse, OpenRouterClient
 from ded_moroz.services import submissions as submissions_service
-from ded_moroz.services.gifts import get_gift_for_day, set_gift
-from ded_moroz.services.logging import log_error
+from ded_moroz.services.gifts import get_gift_for_day, list_gifts, set_gift
+from ded_moroz.services.logging import fetch_recent_errors, log_error
 from ded_moroz.services.users import get_or_create_user, get_user_by_telegram, update_status
 from ded_moroz.utils.time import (
+    current_campaign_day,
     current_day_deadline,
     is_after_deadline,
     is_before_start,
     is_campaign_active,
     is_quiet_hours,
+    now,
     quiet_hours_end,
 )
 
@@ -77,6 +81,21 @@ async def _respond(target: Message | CallbackQuery, text: str, reply_markup: Inl
         message = target
     if message:
         await message.answer(text, reply_markup=reply_markup)
+
+
+async def _ensure_admin(message: Message) -> bool:
+    if is_admin(message.from_user.id):
+        return True
+    await message.answer("У тебя нет прав администратора.")
+    return False
+
+
+def _format_error_entry(error: object) -> str:
+    created_at = getattr(error, "created_at", None)
+    created_part = f" [{created_at.strftime('%d.%m %H:%M')}]" if created_at else ""
+    context = getattr(error, "context", None)
+    context_part = f" — контекст: {context}" if context else ""
+    return f"#{getattr(error, 'id', '?')} [{getattr(error, 'level', '?')}] {getattr(error, 'message', '')}{created_part}{context_part}"
 
 
 @router.message(Command("start"))
@@ -138,7 +157,7 @@ async def cmd_status(message: Message) -> None:
 
 @router.message(Command("admin_stats"))
 async def cmd_admin_stats(message: Message) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     from sqlalchemy import func, select
 
@@ -159,7 +178,7 @@ async def cmd_admin_stats(message: Message) -> None:
 
 @router.message(Command("admin_user"))
 async def cmd_admin_user(message: Message, command: CommandObject) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     if not command.args:
         await message.answer("Используй: /admin_user <telegram_id>")
@@ -178,7 +197,7 @@ async def cmd_admin_user(message: Message, command: CommandObject) -> None:
 
 @router.message(Command("set_gift"))
 async def cmd_set_gift(message: Message, command: CommandObject) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     if not command.args:
         await message.answer("Используй: /set_gift <day> <текст> [url]")
@@ -216,12 +235,18 @@ async def cmd_set_gift(message: Message, command: CommandObject) -> None:
             return
 
     gift = await set_gift(day, gift_type, gift_text, gift_url, payload_data)
+    await log_error(
+        SeverityLevel.INFO,
+        "Gift updated",
+        {"day": day, "gift_type": gift_type.value, "admin_id": message.from_user.id},
+        service_name="gifts",
+    )
     await message.answer(f"Подарок на день {gift.day} обновлён.")
 
 
 @router.message(Command("get_gift"))
 async def cmd_get_gift(message: Message, command: CommandObject) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     if not command.args:
         await message.answer("Используй: /get_gift <day>")
@@ -229,6 +254,12 @@ async def cmd_get_gift(message: Message, command: CommandObject) -> None:
     day = int(command.args.strip())
     gift = await get_gift_for_day(day)
     if not gift:
+        await log_error(
+            SeverityLevel.WARNING,
+            "Gift not found",
+            {"day": day, "admin_id": message.from_user.id},
+            service_name="gifts",
+        )
         await message.answer("Подарок не найден")
         return
     payload_line = f" payload={gift.payload}" if gift.payload else ""
@@ -237,9 +268,37 @@ async def cmd_get_gift(message: Message, command: CommandObject) -> None:
     )
 
 
+@router.message(Command("admin_gifts"))
+async def cmd_admin_gifts(message: Message) -> None:
+    if not await _ensure_admin(message):
+        return
+    gifts = await list_gifts()
+    gifts_by_day = {gift.day: gift for gift in gifts}
+    missing_days: list[int] = []
+    lines = []
+    for day in range(1, settings.campaign.days + 1):
+        gift = gifts_by_day.get(day)
+        if gift:
+            lines.append(f"День {day}: {_format_gift_line(gift)}")
+        else:
+            lines.append(f"День {day}: подарок не настроен")
+            missing_days.append(day)
+    response_parts = ["Статус подарков:", "\n".join(lines)]
+    if missing_days:
+        errors = await fetch_recent_errors(limit=10, service_name="gifts", message_query="Gift")
+        if not errors:
+            errors = await fetch_recent_errors(limit=10, message_query="gift")
+        if errors:
+            response_parts.append("Последние записи журнала по подаркам:")
+            response_parts.extend([_format_error_entry(error) for error in errors])
+        else:
+            response_parts.append("Логов по подаркам пока нет — добавь подарки и повтори команду.")
+    await message.answer("\n".join(response_parts))
+
+
 @router.message(Command("admin_errors"))
 async def cmd_admin_errors(message: Message) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     from sqlalchemy import select
 
@@ -258,7 +317,7 @@ async def cmd_admin_errors(message: Message) -> None:
 
 @router.message(Command("admin_error"))
 async def cmd_admin_error(message: Message, command: CommandObject) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     if not command.args:
         await message.answer("Используй: /admin_error <id>")
@@ -277,7 +336,7 @@ async def cmd_admin_error(message: Message, command: CommandObject) -> None:
 
 @router.message(Command("admin_health"))
 async def cmd_admin_health(message: Message) -> None:
-    if not is_admin(message.from_user.id):
+    if not await _ensure_admin(message):
         return
     from sqlalchemy import select
 
@@ -292,6 +351,56 @@ async def cmd_admin_health(message: Message) -> None:
         return
     lines = [f"{hb.service_name}: {hb.last_beat_at} (freq: {hb.beat_interval_seconds}s)" for hb in heartbeats]
     await message.answer("\n".join(lines))
+
+
+@router.message(Command("campaign_start"))  # noqa: D401
+async def cmd_campaign_start(message: Message, command: CommandObject) -> None:
+    if not await _ensure_admin(message):
+        return
+    if not command.args:
+        current_day = current_campaign_day()
+        await message.answer(
+            f"Текущая дата старта кампании: {settings.campaign.start_date.isoformat()} "
+            f"(сейчас день {current_day} из {settings.campaign.days}).\n"
+            "Чтобы поменять дату, используй: /campaign_start YYYY-MM-DD"
+        )
+        return
+    try:
+        new_start = date.fromisoformat(command.args.strip())
+    except ValueError:
+        await message.answer("Формат даты: YYYY-MM-DD")
+        return
+    settings.campaign.start_date = new_start
+    os.environ["CAMPAIGN_START_DATE"] = new_start.isoformat()
+    await log_error(
+        SeverityLevel.INFO,
+        "Campaign start date updated",
+        {"start_date": new_start.isoformat(), "admin_id": message.from_user.id},
+        service_name="campaign",
+    )
+    await message.answer(
+        f"Старт кампании обновлён на {new_start.isoformat()}. "
+        f"Текущий день: {current_campaign_day()} из {settings.campaign.days}."
+    )
+
+
+@router.message(Command("campaign_reset_dates"))
+async def cmd_campaign_reset_dates(message: Message) -> None:
+    if not await _ensure_admin(message):
+        return
+    today = now().date()
+    settings.campaign.start_date = today
+    os.environ["CAMPAIGN_START_DATE"] = today.isoformat()
+    await log_error(
+        SeverityLevel.INFO,
+        "Campaign dates reset for testing",
+        {"start_date": today.isoformat(), "admin_id": message.from_user.id},
+        service_name="campaign",
+    )
+    await message.answer(
+        "Даты кампании сброшены для тестирования. "
+        f"Старт теперь {today.isoformat()}, расчёт дня начинается заново."
+    )
 
 
 @router.callback_query(F.data == "status:show")

--- a/ded_moroz/handlers/commands.py
+++ b/ded_moroz/handlers/commands.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import logging
 from datetime import date
 from typing import Final
 
@@ -33,6 +34,7 @@ POEM_MAX_LENGTH: Final[int] = 1500
 
 router = Router()
 llm_client = OpenRouterClient()
+logger = logging.getLogger(__name__)
 
 
 def _format_gift_line(gift: object) -> str:
@@ -84,8 +86,17 @@ async def _respond(target: Message | CallbackQuery, text: str, reply_markup: Inl
 
 
 async def _ensure_admin(message: Message) -> bool:
-    if is_admin(message.from_user.id):
+    telegram_id = message.from_user.id
+    if is_admin(telegram_id):
+        logger.info("Admin access granted", extra={"telegram_id": telegram_id, "command": message.text})
         return True
+    await log_error(
+        SeverityLevel.WARNING,
+        "Admin access denied",
+        {"telegram_id": telegram_id, "command": message.text},
+        service_name="bot",
+    )
+    logger.warning("Admin access denied", extra={"telegram_id": telegram_id, "command": message.text})
     await message.answer("У тебя нет прав администратора.")
     return False
 

--- a/ded_moroz/migrations/env.py
+++ b/ded_moroz/migrations/env.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from logging.config import fileConfig
-from sqlalchemy import engine_from_config, pool
-from sqlalchemy import create_engine
+
 from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from ded_moroz.config import settings
 from ded_moroz.db.models import Base
@@ -36,18 +37,37 @@ def run_migrations_offline() -> None:
 
 
 def run_migrations_online() -> None:
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-        url=get_url(),
-    )
+    url = get_url()
 
-    with connectable.connect() as connection:
+    def _configure(connection) -> None:
         context.configure(connection=connection, target_metadata=target_metadata)
 
+    def _run_sync_migrations(connection) -> None:
+        _configure(connection)
         with context.begin_transaction():
             context.run_migrations()
+
+    if url.startswith("postgresql+asyncpg"):
+        connectable: AsyncEngine = create_async_engine(url, poolclass=pool.NullPool)
+
+        async def _run_async_migrations() -> None:
+            async with connectable.begin() as connection:
+                await connection.run_sync(_run_sync_migrations)
+            await connectable.dispose()
+
+        import asyncio
+
+        asyncio.run(_run_async_migrations())
+    else:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+            url=url,
+        )
+
+        with connectable.connect() as connection:
+            _run_sync_migrations(connection)
 
 
 def run_migrations() -> None:

--- a/ded_moroz/services/gifts.py
+++ b/ded_moroz/services/gifts.py
@@ -12,6 +12,12 @@ async def get_gift_for_day(day: int) -> Gift | None:
         return result.scalar_one_or_none()
 
 
+async def list_gifts() -> list[Gift]:
+    async with session_scope() as session:
+        result = await session.execute(select(Gift).order_by(Gift.day))
+        return list(result.scalars())
+
+
 async def set_gift(
     day: int,
     gift_type: GiftType = GiftType.TEXT,

--- a/ded_moroz/services/logging.py
+++ b/ded_moroz/services/logging.py
@@ -27,6 +27,20 @@ async def log_error(
         return record
 
 
+async def fetch_recent_errors(
+    limit: int = 20, service_name: str | None = None, message_query: str | None = None
+) -> list[ErrorLog]:
+    async with session_scope() as session:
+        query = select(ErrorLog)
+        if service_name:
+            query = query.where(ErrorLog.service_name == service_name)
+        if message_query:
+            query = query.where(ErrorLog.message.ilike(f"%{message_query}%"))
+        query = query.order_by(ErrorLog.id.desc()).limit(limit)
+        result = await session.execute(query)
+        return list(result.scalars())
+
+
 async def fetch_pending_admin_errors(limit: int = 50) -> list[AdminErrorQueue]:
     async with session_scope() as session:
         result = await session.execute(


### PR DESCRIPTION
## Summary
- add admin responses and new command to audit all gifts with recent log entries
- record gift updates/missing gifts in the error log and expose recent log filtering
- add commands to manage campaign start date and reset dates for testing

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e3abd5c9c8320830f1b0666bfd205)